### PR TITLE
Update license entry

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,6 @@ from setuptools import setup, find_packages
 with open('README.md') as f:
     readme = f.read()
 
-with open('LICENSE.md') as f:
-    license = f.read()
-
 setup(
     name='spyse-python',
     version='2.2.3',
@@ -16,7 +13,7 @@ setup(
     author='Roman Romanov',
     author_email='roman.romanov@spyse.com',
     url='https://github.com/spyse-com/spyse-python',
-    license=license,
+    license='MIT',
     packages=find_packages(exclude=('tests', 'examples')),
     install_requires=['requests~=2.26.0', 'dataclasses~=0.6', 'dataclasses-json~=0.5.4', 'responses~=0.13.3',
                       'limiter~=0.1.2']


### PR DESCRIPTION
It should be the license identifier and not the license text.

At the moment PyPI shows the content of the `LICENSE.md` file.

This would also allow third-party tools (e. g., `pyp2rpm`) to get the license details in a simple way.